### PR TITLE
Fix calculation of last file ideal position

### DIFF
--- a/judge.c
+++ b/judge.c
@@ -258,7 +258,7 @@ judge_list (char *restrict * flist, struct law *restrict l)
 		  y->ideal = (x->end + MAGICLEAP);
 	      }
 	    else if (z && z->start && labs (z->atime - y->atime) < MAGICTIME)
-	      y->ideal = (z->start - z->blocks - MAGICLEAP);
+              y->ideal = (z->start - y->size - MAGICLEAP);
 	  }
       }
       /* judge */


### PR DESCRIPTION
I think this is a bug so I fix this: It seems that this means to
calculate the ideal position of this file just before the last file in
the order. To do this correctly, we need to subtract y->size and not
y->blocks, as z->start is in bytes and not in blocks.

This is also part of my integration branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unbrice/shake/5)
<!-- Reviewable:end -->
