### PR TITLE
Add support for FIEMAP

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -32,6 +32,8 @@
 #include <attr/attributes.h>	// attr_setf,
 #include <sys/ioctl.h>		// ioctl()
 #include <linux/fs.h>		// FIBMAP, FIGETBSZ
+#include <linux/fiemap.h>	// FIEMAP
+#include <string.h>		// memset
 #include <arpa/inet.h>		// htonl, ntohl
 
 /* The following try to hide Linux-specific leases behind an interface
@@ -223,6 +225,70 @@ get_testimony (struct accused *a, struct law *l)
       sizelog[logs_pos] = -1;
       poslog[logs_pos] = -1;
     }
+  uint fragsize = 0;
+  /* try to use FIEMAP first before falling back to fibmap */
+  struct fiemap *extmap = malloc (sizeof (struct fiemap));
+  if (!extmap)
+    error (1, errno, "%s: malloc() failed", a->name);
+  memset(extmap, 0, sizeof(struct fiemap));
+  extmap->fm_length = a->size;
+  extmap->fm_flags = FIEMAP_FLAG_SYNC;
+  if (-1 != ioctl (a->fd, FS_IOC_FIEMAP, extmap))
+    {
+      extmap = realloc (extmap, sizeof (struct fiemap) + sizeof (struct fiemap_extent) * extmap->fm_mapped_extents);
+      if (!extmap->fm_extents)
+        error (1, errno, "%s: realloc() failed", a->name);
+      extmap->fm_extent_count = extmap->fm_mapped_extents;
+      extmap->fm_mapped_extents = 0;
+      if (-1 != ioctl (a->fd, FS_IOC_FIEMAP, extmap))
+        {
+          llint physpos = 0;
+          uint physsize = 0;
+          for (int i = 0; i < extmap->fm_mapped_extents; i++)
+            {
+              if (INT_MAX == i)
+                break; // the file is too large for FIEMAP
+              llint adjphyspos = physpos + physsize;
+              physpos = extmap->fm_extents[i].fe_physical;
+              physsize = extmap->fm_extents[i].fe_length;
+              /* ensure the extent is no hole (sparse) and not tailed, nor inline, nor shared */
+              if (physpos && !(extmap->fm_extents[i].fe_flags & (FIEMAP_EXTENT_UNKNOWN|FIEMAP_EXTENT_NOT_ALIGNED|FIEMAP_EXTENT_SHARED)))
+                {
+                  if (!a->start)
+                    a->start = physpos;
+                  a->end = physpos + fragsize;
+                  /* Check if extent is not adjacent */
+                  if (llabs (physpos - adjphyspos) > MAGICLEAP)
+                    {
+                      /* log it */
+                      if (l->verbosity >= 3)
+                        {
+                          /* Periodically enlarge the log */
+                          if (0 == (logs_pos + 2) % BUFFSTEP)
+                            {
+                              size_t nsize = (logs_pos + 2 + BUFFSTEP) * sizeof (*sizelog);
+                              sizelog = realloc (sizelog, nsize);
+                              poslog = realloc (poslog, nsize);
+                              if (!sizelog || !poslog)
+                                error (1, errno, "%s: malloc() failed", a->name);
+                            }
+                          /* Record the pos of the new frag */
+                          poslog[logs_pos] = physpos;
+                          /* Record the size of the new frag */
+                          sizelog[logs_pos] = fragsize;
+                          logs_pos++;
+                        }
+                      if (fragsize && fragsize < crumbsize)
+                        a->crumbc++;
+                      a->fragc++;
+                      fragsize = 0;
+                    }
+                }
+              fragsize += physsize;
+            }
+        }
+      goto out;
+    }
   /*  FIBMAP return physical block's position. We use it to detect start and end
    * of fragments, by checking if the physical position of a block is not
    * adjacent to the previous one.
@@ -231,7 +297,6 @@ get_testimony (struct accused *a, struct law *l)
    */
   {
     llint physpos = 0, prevphyspos = 0;
-    uint fragsize = 0;
     for (int i = 0; i < a->blocks; i++)
       {
 	if (INT_MAX == i)
@@ -299,5 +364,18 @@ get_testimony (struct accused *a, struct law *l)
 	a->sizelog = sizelog;
       }
   }
+out:
+  /* Record the last size, and close the log */
+  if (l->verbosity >= 3 && fragsize)
+    {
+      if (logs_pos)
+        sizelog[logs_pos - 1] = fragsize;
+      poslog[logs_pos] = -1;
+      sizelog[logs_pos] = -1;
+      a->poslog = poslog;
+      a->sizelog = sizelog;
+    }
+  if (extmap)
+    free (extmap);
   return 0;
 }


### PR DESCRIPTION
This patch adds support for FIEMAP and leaves the current FIBMAP
approach in place as a fallback. Instead of trying to guess extents from
FIBMAP block maps, it directly uses extents as fragments.

The logic is similar as it merges adjecent extents as one fragment. It
also detects hole extents and inlined extents and doesn't account those
as fragments similar to the FIBMAP approach.

It optimizes handling filesystems with tail support (e.g., reiserfs) by
not accounting tailed extents as fragments, as the rewrite process
probably would tail the last extent again.

Similarily it tries to optimize for file systems that support shared
extents (xfs, btrfs) by not accounting such extents as fragments. This
helps preventing unsharing accused files and thus increasing space
usage. I pretend that keeping shared extents is more important than
continuous extents, as the operation of deduplicating those extents in
the first place is known to fragment those files.

However, if the heuristics decide to shake the file, extents still
become unshared. I have no idea currently how to optimize for that, thus
it is not part of this patch.

This is also part of my integration branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unbrice/shake/7)
<!-- Reviewable:end -->
