### PR TITLE
Improve performance and add reflink support

### DIFF
--- a/executive.c
+++ b/executive.c
@@ -320,6 +320,15 @@ shake_reg (struct accused *a, struct law *l)
       return -1;
     }
 
+  /* ensure nothing has gone wrong
+   */
+  struct stat astat, lstat;
+  if (0 > fstat (a->fd, &astat))
+    error (1, errno, "%s: fstat() failed", a->name);
+  if (0 > fstat (l->tmpfd, &lstat))
+    error (1, errno, "%s: fstat() failed", l->tmpname);
+  assert (astat.st_size == lstat.st_size);
+
   /* Tries acquiring a write lock and then to copy the backup over the
    * original.
    */

--- a/executive.c
+++ b/executive.c
@@ -230,6 +230,7 @@ static int
 shake_reg_backup_phase (struct accused *a, struct law *l)
 {
   /* truncate the backup file first, also required for FICLONE to be effective
+   * TODO: use openat(TMP_FILE) instead
    */
   int res = ftruncate (l->tmpfd, 0);
   if (0 == res)

--- a/executive.c
+++ b/executive.c
@@ -229,13 +229,39 @@ release (struct accused *a, struct law *l)
 static int
 shake_reg_backup_phase (struct accused *a, struct law *l)
 {
-  /* truncate the backup file first
+  static int can_reflink = 1;
+  /* truncate the backup file first, also required for FICLONE to be effective
    */
   int res = ftruncate (l->tmpfd, 0);
   if (0 == res)
     {
-      posix_fadvise (a->fd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
-      res = fcopy (a->fd, l->tmpfd, MAGICLEAP, l->locks);
+      /* try to make a reflink copy first on filesystems that support it,
+       * this saves us from writing the file twice, thus double the
+       * performance
+       */
+      if (can_reflink && (0 == ioctl (l->tmpfd, FICLONE, a->fd)))
+        {
+          /* give the filesystem a relief
+           */
+          fdatasync (l->tmpfd);
+        }
+      else
+        {
+          if (can_reflink)
+            {
+              /* optimize: do not try any more cloning if it failed once,
+               * this assumes you're not crossing file system boundaries.
+               * TODO: fix this later by putting the tmp file on the same
+               * file system
+               */
+              can_reflink = 0;
+              error (0, errno,
+                     "%s: FICLONE failed, falling back to normal copy",
+                     a->name);
+            }
+          posix_fadvise (a->fd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
+          res = fcopy (a->fd, l->tmpfd, MAGICLEAP, l->locks);
+        }
     }
   if (0 > res || has_been_unlocked (a, l))
     return -1;

--- a/executive.c
+++ b/executive.c
@@ -236,12 +236,14 @@ shake_reg_backup_phase (struct accused *a, struct law *l)
     {
       posix_fadvise (a->fd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
       res = fcopy (a->fd, l->tmpfd, MAGICLEAP, l->locks);
-      posix_fadvise (l->tmpfd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
     }
   if (0 > res || has_been_unlocked (a, l))
     return -1;
   else
-    return 0;
+    {
+      posix_fadvise (l->tmpfd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
+      return 0;
+    }
 }
 
 /* Rewrites a->fd from l->tmpfd. Second halve of shake_reg() .

--- a/executive.c
+++ b/executive.c
@@ -37,6 +37,11 @@
 #include <dirent.h>             // opendir()
 #include <sys/time.h>           // futimes()
 
+# ifndef FICLONE
+#  define FICLONE _IOW(0x94, 9, int) // linux/fs.h since kernel 4.5
+# endif
+
+
 int
 fclone (int in_fd, int out_fd)
 {

--- a/executive.c
+++ b/executive.c
@@ -176,7 +176,7 @@ fcopy (int in_fd, int out_fd, size_t gap, bool stop_if_input_unlocked)
         errno = 0;              // the error would be in the check and so meaningless
         return -1;
       }
-  }
+    }
   return 1;
 }
 

--- a/executive.c
+++ b/executive.c
@@ -50,7 +50,7 @@ fcopy (int in_fd, int out_fd, size_t gap, bool stop_if_input_unlocked)
     return -1;
   /* Optimisation (on Linux it double the readahead window) */
   posix_fadvise (in_fd, (off_t) 0, (off_t) 0, POSIX_FADV_SEQUENTIAL);
-  posix_fadvise (in_fd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
+  posix_fadvise (in_fd, (off_t) 0, (off_t) 0, POSIX_FADV_NOREUSE);
   /* Get a buffer... */
   {
     if (gap)
@@ -230,7 +230,9 @@ release (struct accused *a, struct law *l)
 static int
 shake_reg_backup_phase (struct accused *a, struct law *l)
 {
+  posix_fadvise (a->fd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
   const int res = fcopy (a->fd, l->tmpfd, MAGICLEAP, l->locks);
+  posix_fadvise (l->tmpfd, (off_t) 0, (off_t) 0, POSIX_FADV_WILLNEED);
   if (0 > res || has_been_unlocked (a, l))
     return -1;
   else
@@ -265,11 +267,17 @@ shake_reg_rewrite_phase (struct accused *a, struct law *l)
   if (0 > ftruncate (a->fd, (off_t) 0))
     error (1, errno,
            "%s: failed to ftruncate() ! file have been saved at %s",
+	         a->name, l->tmpname);
+  if (0 > fallocate(a->fd, FALLOC_FL_KEEP_SIZE, 0, a->size))
+    error (1, errno,
+           "%s: failed to allocate space! file has been saved at %s",
            a->name, l->tmpname);
   /* Do the reverse copying */
   if (0 > fcopy (l->tmpfd, a->fd, GAP, false))
     error (1, errno, "%s: restore failed ! file have been saved at %s",
            a->name, l->tmpname);
+  posix_fadvise (a->fd, (off_t) 0, (off_t) 0, POSIX_FADV_DONTNEED);
+  posix_fadvise (l->tmpfd, (off_t) 0, (off_t) 0, POSIX_FADV_DONTNEED);
   /* Restores most signals */
   enter_normal_mode ();
   free (msg);

--- a/judge.c
+++ b/judge.c
@@ -256,7 +256,7 @@ judge_list (char *restrict * flist, struct law *restrict l)
                   y->ideal = (x->end + MAGICLEAP);
               }
             else if (z && z->start && labs (z->atime - y->atime) < MAGICTIME)
-              y->ideal = (z->start - z->blocks - MAGICLEAP);
+              y->ideal = (z->start - y->size - MAGICLEAP);
           }
       }
       /* judge */

--- a/linux.c
+++ b/linux.c
@@ -32,6 +32,8 @@
 #include <attr/attributes.h>    // attr_setf,
 #include <sys/ioctl.h>          // ioctl()
 #include <linux/fs.h>           // FIBMAP, FIGETBSZ
+#include <linux/fiemap.h>       // FIEMAP
+#include <string.h>             // memset
 #include <arpa/inet.h>          // htonl, ntohl
 
 /* The following try to hide Linux-specific leases behind an interface
@@ -221,6 +223,70 @@ get_testimony (struct accused *a, struct law *l)
       sizelog[logs_pos] = -1;
       poslog[logs_pos] = -1;
     }
+  uint fragsize = 0;
+  /* try to use FIEMAP first before falling back to fibmap */
+  struct fiemap *extmap = malloc (sizeof (struct fiemap));
+  if (!extmap)
+    error (1, errno, "%s: malloc() failed", a->name);
+  memset(extmap, 0, sizeof(struct fiemap));
+  extmap->fm_length = a->size;
+  extmap->fm_flags = FIEMAP_FLAG_SYNC;
+  if (-1 != ioctl (a->fd, FS_IOC_FIEMAP, extmap))
+    {
+      extmap = realloc (extmap, sizeof (struct fiemap) + sizeof (struct fiemap_extent) * extmap->fm_mapped_extents);
+      if (!extmap->fm_extents)
+        error (1, errno, "%s: realloc() failed", a->name);
+      extmap->fm_extent_count = extmap->fm_mapped_extents;
+      extmap->fm_mapped_extents = 0;
+      if (-1 != ioctl (a->fd, FS_IOC_FIEMAP, extmap))
+        {
+          llint physpos = 0;
+          uint physsize = 0;
+          for (int i = 0; i < extmap->fm_mapped_extents; i++)
+            {
+              if (INT_MAX == i)
+                break; // the file is too large for FIEMAP
+              llint adjphyspos = physpos + physsize;
+              physpos = extmap->fm_extents[i].fe_physical;
+              physsize = extmap->fm_extents[i].fe_length;
+              /* ensure the extent is no hole (sparse) and not tailed, nor inline, nor shared */
+              if (physpos && !(extmap->fm_extents[i].fe_flags & (FIEMAP_EXTENT_UNKNOWN|FIEMAP_EXTENT_NOT_ALIGNED|FIEMAP_EXTENT_SHARED)))
+                {
+                  if (!a->start)
+                    a->start = physpos;
+                  a->end = physpos + fragsize;
+                  /* Check if extent is not adjacent */
+                  if (llabs (physpos - adjphyspos) > MAGICLEAP)
+                    {
+                      /* log it */
+                      if (l->verbosity >= 3)
+                        {
+                          /* Periodically enlarge the log */
+                          if (0 == (logs_pos + 2) % BUFFSTEP)
+                            {
+                              size_t nsize = (logs_pos + 2 + BUFFSTEP) * sizeof (*sizelog);
+                              sizelog = realloc (sizelog, nsize);
+                              poslog = realloc (poslog, nsize);
+                              if (!sizelog || !poslog)
+                                error (1, errno, "%s: malloc() failed", a->name);
+                            }
+                          /* Record the pos of the new frag */
+                          poslog[logs_pos] = physpos;
+                          /* Record the size of the new frag */
+                          sizelog[logs_pos] = fragsize;
+                          logs_pos++;
+                        }
+                      if (fragsize && fragsize < crumbsize)
+                        a->crumbc++;
+                      a->fragc++;
+                      fragsize = 0;
+                    }
+                }
+              fragsize += physsize;
+            }
+        }
+      goto out;
+    }
   /*  FIBMAP return physical block's position. We use it to detect start and end
    * of fragments, by checking if the physical position of a block is not
    * adjacent to the previous one.
@@ -229,7 +295,6 @@ get_testimony (struct accused *a, struct law *l)
    */
   {
     llint physpos = 0, prevphyspos = 0;
-    uint fragsize = 0;
     for (int i = 0; i < a->blocks; i++)
       {
         if (INT_MAX == i)
@@ -297,5 +362,18 @@ get_testimony (struct accused *a, struct law *l)
         a->sizelog = sizelog;
       }
   }
+out:
+  /* Record the last size, and close the log */
+  if (l->verbosity >= 3 && fragsize)
+    {
+      if (logs_pos)
+        sizelog[logs_pos - 1] = fragsize;
+      poslog[logs_pos] = -1;
+      sizelog[logs_pos] = -1;
+      a->poslog = poslog;
+      a->sizelog = sizelog;
+    }
+  if (extmap)
+    free (extmap);
   return 0;
 }

--- a/linux.h
+++ b/linux.h
@@ -32,7 +32,6 @@
 /* Called once, perform OS-specific tasks.
  */
 int os_specific_setup (const char *tempfile);
-
 
 
 /* Get a write lock on the file.

--- a/linux.h
+++ b/linux.h
@@ -29,10 +29,6 @@
 
 # define OS_RESERVED_SIGNAL 16
 
-# ifndef FICLONE
-#  define FICLONE _IOW(0x94, 9, int) // linux/fs.h since kernel 4.5
-# endif
-
 /* Called once, perform OS-specific tasks.
  */
 int os_specific_setup (const char *tempfile);

--- a/linux.h
+++ b/linux.h
@@ -29,6 +29,10 @@
 
 # define OS_RESERVED_SIGNAL 16
 
+# ifndef FICLONE
+#  define FICLONE _IOW(0x94, 9, int) // linux/fs.h since kernel 4.5
+# endif
+
 /* Called once, perform OS-specific tasks.
  */
 int os_specific_setup (const char *tempfile);

--- a/linux.h
+++ b/linux.h
@@ -53,7 +53,6 @@ int readlock_to_writelock (int fd);
 /* Return true if fd is locked, else false
  */
 bool is_locked (int fd);
-
 
 
 /* Declares the glibc function

--- a/main.c
+++ b/main.c
@@ -67,9 +67,9 @@
 #include <error.h>
 #include <string.h>
 
-#include <unistd.h>		// unlink()
-#include <sys/types.h>		// umask()
-#include <sys/stat.h>		// umask()
+#include <unistd.h>             // unlink()
+#include <sys/types.h>          // umask()
+#include <sys/stat.h>           // umask()
 #include "linux.h"
 #include "judge.h"
 #include "executive.h"
@@ -123,12 +123,12 @@ parseopts (int argc, char **restrict argv, struct law *restrict l)
   const time_t mB = 1000 * kB;
   /* Default values - fields are described in judge.h */
   {
-    l->maxfragc = 21;		// 10 sec per frag on a 210 sec OGG Vorbis
-    l->crumbratio = 0.95 / 100;	// 2 sec of a 210 sec OGG Vorbis
-    l->maxcrumbc = 9;		// A magic number.
-    l->smallsize = 16 * kB;	// Config files
-    l->smallsize_tol = 0.1;	// 2 frag max for a config file
-    l->bigsize = 95 * mB;	// Takes 7 sec to shake()
+    l->maxfragc = 21;           // 10 sec per frag on a 210 sec OGG Vorbis
+    l->crumbratio = 0.95 / 100; // 2 sec of a 210 sec OGG Vorbis
+    l->maxcrumbc = 9;           // A magic number.
+    l->smallsize = 16 * kB;     // Config files
+    l->smallsize_tol = 0.1;     // 2 frag max for a config file
+    l->bigsize = 95 * mB;       // Takes 7 sec to shake()
     l->bigsize_tol = MAX_TOL;
     l->maxdeviance = MAGICLEAP * 4;
     l->old = 8 * 31 * day;
@@ -136,7 +136,7 @@ parseopts (int argc, char **restrict argv, struct law *restrict l)
     l->pretend = false;
     l->verbosity = 0;
     l->locks = true;
-    l->kingdom = 0;		// --many-fs disabled
+    l->kingdom = 0;             // --many-fs disabled
     l->xattr = 1;
   }
   /* Like the manpage said .. */
@@ -145,96 +145,96 @@ parseopts (int argc, char **restrict argv, struct law *restrict l)
       int c;
       /* Associate long names to short ones */
       static const struct option long_options[] = {
-	{"max-crumbc", required_argument, NULL, 'c'},
-	{"max-fragc", required_argument, NULL, 'C'},
-	{"max-deviance", required_argument, NULL, 'd'},
-	{"help", no_argument, NULL, 'h'},
-	{"no-locks", no_argument, NULL, 'L'},
-	{"many-fs", no_argument, NULL, 'm'},
-	{"new", required_argument, NULL, 'n'},
-	{"old", required_argument, NULL, 'o'},
-	{"pretend", no_argument, NULL, 'p'},
-	{"verbose", no_argument, NULL, 'v'},
-	{"crumbratio", required_argument, NULL, 'r'},
-	{"smallsize", required_argument, NULL, 's'},
-	{"bigsize", required_argument, NULL, 'S'},
-	{"small-tolerance", required_argument, NULL, 't'},
-	{"big-tolerance", required_argument, NULL, 'T'},
-	{"version", no_argument, NULL, 'V'},
-	{"no-xattr", no_argument, NULL, 'X'},
-	{0, 0, 0, 0}
+        {"max-crumbc", required_argument, NULL, 'c'},
+        {"max-fragc", required_argument, NULL, 'C'},
+        {"max-deviance", required_argument, NULL, 'd'},
+        {"help", no_argument, NULL, 'h'},
+        {"no-locks", no_argument, NULL, 'L'},
+        {"many-fs", no_argument, NULL, 'm'},
+        {"new", required_argument, NULL, 'n'},
+        {"old", required_argument, NULL, 'o'},
+        {"pretend", no_argument, NULL, 'p'},
+        {"verbose", no_argument, NULL, 'v'},
+        {"crumbratio", required_argument, NULL, 'r'},
+        {"smallsize", required_argument, NULL, 's'},
+        {"bigsize", required_argument, NULL, 'S'},
+        {"small-tolerance", required_argument, NULL, 't'},
+        {"big-tolerance", required_argument, NULL, 'T'},
+        {"version", no_argument, NULL, 'V'},
+        {"no-xattr", no_argument, NULL, 'X'},
+        {0, 0, 0, 0}
       };
       c =
-	getopt_long (argc, argv, "c:C:d:hL:mn:o:pvr:s:S:t:T:VWX",
-		     long_options, NULL);
+        getopt_long (argc, argv, "c:C:d:hL:mn:o:pvr:s:S:t:T:VWX",
+                     long_options, NULL);
       if (c == -1)
-	break;
+        break;
       switch (c)
-	{
-	case 'c':
-	  l->maxcrumbc = argtoi (optarg, 0, "max-crumbc");
-	  break;
-	case 'C':
-	  l->maxfragc = argtoi (optarg, 0, "max-fragc");
-	  break;
-	case 'd':
-	  l->maxdeviance = argtoi (optarg, 0, "max-deviance");
-	  break;
-	case 'h':
-	  show_help ();
-	  exit (0);
-	case 'L':
-	  l->locks = false;
-	  break;
-	case 'm':
-	  l->kingdom = (dev_t) - 1;	// ignore filesystems
-	  break;
-	case 'n':
-	  l->new = day * argtoi (optarg, 0, "new");
-	  if (l->new > l->old)
-	    l->old = l->new;
-	  break;
-	case 'o':
-	  l->old = day * argtoi (optarg, 0, "old");
-	  if (l->old < l->new)
-	    l->new = l->old;
-	  break;
-	case 'p':
-	  l->pretend = true;
-	  break;
-	case 'r':
-	  l->crumbratio = argtof (optarg, 0, "crumbratio");
-	  break;
-	case 's':
-	  l->smallsize = kB * argtoi (optarg, 0, "small-size");
-	  if (l->smallsize > l->bigsize)
-	    l->bigsize = l->smallsize;
-	  break;
-	case 'S':
-	  l->bigsize = kB * argtoi (optarg, 0, "big-size");
-	  if (l->bigsize < l->smallsize)
-	    l->smallsize = l->bigsize;
-	  break;
-	case 't':
-	  l->smallsize_tol = argtof (optarg, 0, "tolerance");
-	  break;
-	case 'T':
-	  l->bigsize_tol = argtof (optarg, 0, "tolerance");
-	  break;
-	case 'v':
-	  l->verbosity++;
-	  break;
-	case 'V':
-	  show_version ();
-	  exit (0);
-	case 'X':
-	  l->xattr = 0;
-	  break;
-	case 0:
-	case '?':
-	default:
-	  error (1, 0, "invalid args, aborting");
-	}
+        {
+        case 'c':
+          l->maxcrumbc = argtoi (optarg, 0, "max-crumbc");
+          break;
+        case 'C':
+          l->maxfragc = argtoi (optarg, 0, "max-fragc");
+          break;
+        case 'd':
+          l->maxdeviance = argtoi (optarg, 0, "max-deviance");
+          break;
+        case 'h':
+          show_help ();
+          exit (0);
+        case 'L':
+          l->locks = false;
+          break;
+        case 'm':
+          l->kingdom = (dev_t) - 1;     // ignore filesystems
+          break;
+        case 'n':
+          l->new = day * argtoi (optarg, 0, "new");
+          if (l->new > l->old)
+            l->old = l->new;
+          break;
+        case 'o':
+          l->old = day * argtoi (optarg, 0, "old");
+          if (l->old < l->new)
+            l->new = l->old;
+          break;
+        case 'p':
+          l->pretend = true;
+          break;
+        case 'r':
+          l->crumbratio = argtof (optarg, 0, "crumbratio");
+          break;
+        case 's':
+          l->smallsize = kB * argtoi (optarg, 0, "small-size");
+          if (l->smallsize > l->bigsize)
+            l->bigsize = l->smallsize;
+          break;
+        case 'S':
+          l->bigsize = kB * argtoi (optarg, 0, "big-size");
+          if (l->bigsize < l->smallsize)
+            l->smallsize = l->bigsize;
+          break;
+        case 't':
+          l->smallsize_tol = argtof (optarg, 0, "tolerance");
+          break;
+        case 'T':
+          l->bigsize_tol = argtof (optarg, 0, "tolerance");
+          break;
+        case 'v':
+          l->verbosity++;
+          break;
+        case 'V':
+          show_version ();
+          exit (0);
+        case 'X':
+          l->xattr = 0;
+          break;
+        case 0:
+        case '?':
+        default:
+          error (1, 0, "invalid args, aborting");
+        }
     }
   return optind;
 }
@@ -254,7 +254,7 @@ xmkstemp (char *basename)
   fd = mkstemp (basename);
   errsv = errno;
   umask (oldmask);
-  errno = errsv;		// restore mkstemp's errno
+  errno = errsv;                // restore mkstemp's errno
   return fd;
 }
 
@@ -290,14 +290,14 @@ main (int argc, char **argv)
   else
     for (int i = optind; i != argc; i++)
       {
-	int jugement;
-	a = investigate (argv[i], &l);
-	if (NULL == a)
-	  continue;		// error have been displayed by investigate()
-	if ((dev_t) - 1 != l.kingdom)	// --one-file-system
-	  l.kingdom = a->fs;
-	jugement = judge (a, &l);
-	close_case (a, &l);
+        int jugement;
+        a = investigate (argv[i], &l);
+        if (NULL == a)
+          continue;             // error have been displayed by investigate()
+        if ((dev_t) - 1 != l.kingdom)   // --one-file-system
+          l.kingdom = a->fs;
+        jugement = judge (a, &l);
+        close_case (a, &l);
       }
   unlink (tmpname);
   free (tmpname);

--- a/main.c
+++ b/main.c
@@ -290,13 +290,12 @@ main (int argc, char **argv)
   else
     for (int i = optind; i != argc; i++)
       {
-        int jugement;
         a = investigate (argv[i], &l);
         if (NULL == a)
           continue;             // error have been displayed by investigate()
         if ((dev_t) - 1 != l.kingdom)   // --one-file-system
           l.kingdom = a->fs;
-        jugement = judge (a, &l);
+        judge (a, &l);
         close_case (a, &l);
       }
   unlink (tmpname);


### PR DESCRIPTION
This branch adds a few cleanups first to fix indentation and an issue reported by the compiler. It then adds a series of patches which try to improve performance.

The most important patch is support for the FICLONE ioctl which yields a performance boost of 50% on filesystems supporting it. No thorough testing has been done, it may eat your kitten. Please do your own checks. I tested this against some big files multiple times comparing md5sums before and after and it reported no data damage, so it seems to work.

This builds upon my integration branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unbrice/shake/14)
<!-- Reviewable:end -->
