### PR TITLE
Improve and explain ideal file positioning

### DIFF
--- a/judge.c
+++ b/judge.c
@@ -246,17 +246,24 @@ judge_list (char *restrict * flist, struct law *restrict l)
       /* Do we know where the file should be ? */
       {
         y->ideal = 0;
+        /* Ideal file order: x->start < y->start < z->start
+         *                              ^^^^^^^^
+         *                          File to be moved
+         */
         if (y->start)
           {
             if (x && x->end && labs (x->atime - y->atime) < MAGICTIME)
               {
                 if (z && z->start && labs (z->atime - y->atime) < MAGICTIME)
-                  y->ideal = (x->end + z->start) / 2;
+                  /* place the middle file between the left and right file */
+                  y->ideal = (x->end + z->start + MAGICLEAP - y->size) / 2;
                 else
+                  /* place the middle file directly after the left file */
                   y->ideal = (x->end + MAGICLEAP);
               }
             else if (z && z->start && labs (z->atime - y->atime) < MAGICTIME)
-              y->ideal = (z->start - z->size - MAGICLEAP);
+              /* place the middle file directly in front of the right file */
+              y->ideal = (z->start - y->size - MAGICLEAP);
           }
       }
       /* judge */


### PR DESCRIPTION
Explain what x, y, and z files are (left, middle, right). Also fixes two
problems:

1. The middle file should be centered between the left and right files,
   thus we need to take the middle file size into account.

2. To place the middle file in front of the right file, we need subtract
   the size of the middle file, not that of the right file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unbrice/shake/18)
<!-- Reviewable:end -->
